### PR TITLE
Fix embedder corpus parsing

### DIFF
--- a/api/embedder.py
+++ b/api/embedder.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import List
+import json
 
 try:
     from sentence_transformers import SentenceTransformer, util
@@ -27,7 +28,7 @@ def _load_corpus() -> List[str]:
         for line in path.read_text(encoding="utf-8").splitlines():
             if line.strip():
                 try:
-                    texts.append(eval(line).get("text", ""))
+                    texts.append(json.loads(line).get("text", ""))
                 except Exception:
                     pass
     return texts


### PR DESCRIPTION
## Summary
- use `json.loads` instead of `eval` when reading memory files
- add missing `json` import

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68817d8e496083228c238d19fde79b36