### PR TITLE
docs: clarify client communication requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,36 @@ A simple FastAPI service providing contextual information from memory and knowle
 
 ## Authentication
 
-Register via `POST /auth/register`. The account must be approved by an administrator
-before an API key is issued. Once approved, obtain the API key using
-`POST /auth/token`.
+Register via `POST /auth/register` using a JSON body with `username`, `password`
+and `email`. The account must be approved by an administrator before an API key is
+issued. Once approved, obtain the API key with `POST /auth/token` by providing the
+same `username` and `password`.
+
+## Client communication requirements
+
+All requests (except those under `/auth`) require an API key and use JSON payloads.
+
+1. **Registration** – send `POST /auth/register` with the user's credentials and
+   wait for administrator approval.
+2. **Login** – after approval, call `POST /auth/token` with the login credentials
+   to receive an `api_key`.
+3. **Authenticated calls** – include the API key in the header of every other
+   request:
+
+   ```bash
+   Authorization: Bearer <api_key>
+   ```
+
+   Example: fetching context for a query
+
+   ```bash
+   curl -X POST https://<host>/get_context \
+     -H "Authorization: Bearer YOUR_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{"query": "Hello"}'
+   ```
+
+   Without a valid and approved API key the service returns `401` or `403` errors.
 
 ## Creating users via script
 


### PR DESCRIPTION
## Summary
- expand authentication docs with JSON payload details
- document full client workflow from registration to authenticated requests
- add curl example for using API key

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68937cb795088322a26a5691a9f53de5