### PR TITLE
feat: add API key auth middleware

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 # main.py
 from fastapi import FastAPI
-from middleware import ApiKeyMiddleware
+from middleware import APIKeyAuthMiddleware
 from user_endpoint import router as user_router
 from api.get_context import router as ctx_router
 from api.auth import router as auth_router
@@ -10,7 +10,7 @@ app = FastAPI(title="Otec Fura API")
 
 # Povolené cesty bez auth (chceš-li vše zamknout, dej prázdnou množinu)
 allow = {"/openapi.json", "/docs", "/redoc", "/favicon.ico", "/auth"}
-app.add_middleware(ApiKeyMiddleware, allow_paths=allow)
+app.add_middleware(APIKeyAuthMiddleware, allow_paths=allow)
 
 @app.get("/")
 def root():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,7 @@ import json
 import pytest
 import asyncio
 from pathlib import Path
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -126,6 +126,16 @@ def test_root(auth_header):
     resp = client.get("/", headers=auth_header)
     assert resp.status_code == 200
     assert resp.json() == {"message": "Otec Fura API"}
+
+
+def test_current_user_in_state(auth_header):
+    @app.get("/me")
+    def me(request: Request):
+        return request.state.current_user
+
+    resp = client.get("/me", headers=auth_header)
+    assert resp.status_code == 200
+    assert resp.json()["username"] == "tester"
 
 
 def test_get_context(monkeypatch, auth_header):


### PR DESCRIPTION
## Summary
- rename middleware to APIKeyAuthMiddleware and accept allow path set
- centralize user database path via USERS_FILE constant
- store authenticated user in `request.state.current_user`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b71bb373c8322a7b15663041182ad