### PR TITLE
Guard user endpoint when API key missing

### DIFF
--- a/api/user_endpoint.py
+++ b/api/user_endpoint.py
@@ -1,19 +1,19 @@
 # user_endpoint.py
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, HTTPException
 
 router = APIRouter()
 
 @router.get("/user")
 async def get_user(request: Request):
-    u = getattr(request.state, "current_user", None)
-    # pokud by middleware nebyl u rootu, vrátíme 401/403 – ale díky middleware se sem bez usera nedostane
-    if not u:
-        return {"detail": "Neplatný API klíč"}
+    current_user = getattr(request.state, "current_user", None)
+    # pokud by middleware nebyl u rootu, vrátíme 401 – ale díky middleware se sem bez usera nedostane
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Neplatný API klíč")
     # nevracej password_hash
     return {
-        "username": u.get("username"),
-        "email": u.get("email"),
-        "api_key": u.get("api_key"),
-        "approved": u.get("approved"),
-        "created_at": u.get("created_at"),
+        "username": current_user.get("username"),
+        "email": current_user.get("email"),
+        "api_key": current_user.get("api_key"),
+        "approved": current_user.get("approved"),
+        "created_at": current_user.get("created_at"),
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -138,6 +138,18 @@ def test_current_user_in_state(auth_header):
     assert resp.json()["username"] == "tester"
 
 
+def test_user_endpoint(auth_header):
+    resp = client.get("/user", headers=auth_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["username"] == "tester"
+
+
+def test_user_endpoint_unauthorized():
+    resp = client.get("/user")
+    assert resp.status_code == 401
+
+
 def test_get_context(monkeypatch, auth_header):
     def dummy_embed(query: str, top_k: int = 3):
         return [f"embedded:{query}"]

--- a/user_endpoint.py
+++ b/user_endpoint.py
@@ -1,19 +1,19 @@
 # user_endpoint.py
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, HTTPException
 
 router = APIRouter()
 
 @router.get("/user")
 async def get_user(request: Request):
-    u = getattr(request.state, "current_user", None)
-    # pokud by middleware nebyl u rootu, vrátíme 401/403 – ale díky middleware se sem bez usera nedostane
-    if not u:
-        return {"detail": "Neplatný API klíč"}
+    current_user = getattr(request.state, "current_user", None)
+    # pokud by middleware nebyl u rootu, vrátíme 401 – ale díky middleware se sem bez usera nedostane
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Neplatný API klíč")
     # nevracej password_hash
     return {
-        "username": u.get("username"),
-        "email": u.get("email"),
-        "api_key": u.get("api_key"),
-        "approved": u.get("approved"),
-        "created_at": u.get("created_at"),
+        "username": current_user.get("username"),
+        "email": current_user.get("email"),
+        "api_key": current_user.get("api_key"),
+        "approved": current_user.get("approved"),
+        "created_at": current_user.get("created_at"),
     }


### PR DESCRIPTION
## Summary
- Ensure `/user` endpoint matches middleware's `current_user` attribute
- Return HTTP 401 when no user is set
- Add tests for authorized and unauthorized access to `/user`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689b749b87b4832294cd48dfc591d6af