### PR TITLE
Use SECRET_KEY from environment

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,3 @@
+# Sample environment configuration
+# Replace with a strong secret key in production
+SECRET_KEY=dev-secret-key

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ otec_fura/
 └─ memory/
    └─ public.jsonl         ← volitelné (veřejné „věty“ do memory)
 
+## Configuration
+
+The application reads configuration from environment variables. Create a `.env`
+file (see `.env.sample`) or export variables in your shell.
+
+- `SECRET_KEY` – secret key used to sign tokens. A development default is used
+  if this variable is not set, but it should be overridden in production.
 
 ## Endpoints
 

--- a/config.py
+++ b/config.py
@@ -1,2 +1,6 @@
+import os
+
 API_PORT = 8090
-SECRET_KEY = "a537047637d1ad5fb90f8980db97975cbacc5b9eef0c4bb778e15e12e32e40ac"
+# Use an environment variable for the secret key. Provide a development default
+# so the application can run without explicit configuration.
+SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-key")


### PR DESCRIPTION
## Summary
- load SECRET_KEY from environment with a safe development default
- document SECRET_KEY in README and provide sample .env file

## Testing
- `pytest -q` *(fails: assert 404 == 401; 3 failed, 2 passed, 6 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68b73a14f7e08322905868bf886cf0e7