### PR TITLE
feat: add request model for context endpoint

### DIFF
--- a/api/get_context.py
+++ b/api/get_context.py
@@ -1,17 +1,23 @@
 # api/get_context.py
-from fastapi import APIRouter, Request
+from fastapi import APIRouter
+from pydantic import BaseModel
 from api.get_memory import load_memory_context, append_to_memory
 from api.search_knowledge import search_knowledge
 from api.embedder import embed_and_query
 
 router = APIRouter()
 
+class GetContextRequest(BaseModel):
+    query: str = ""
+    user: str = "anonymous"
+    remember: bool = False
+
+
 @router.post("/get_context")
-async def get_context(request: Request):
-    body = await request.json()
-    query: str = body.get("query", "")
-    user: str = body.get("user", "anonymous")
-    remember: bool = bool(body.get("remember", False))
+async def get_context(body: GetContextRequest):
+    query = body.query
+    user = body.user
+    remember = body.remember
 
     memory_ctx = load_memory_context(user, query)
     knowledge_ctx = search_knowledge(query)


### PR DESCRIPTION
## Summary
- add `GetContextRequest` Pydantic model with query, user, and remember fields
- refactor `/get_context` endpoint to use request model for automatic validation

## Testing
- `pytest -q` *(fails: assert 404 == 200 in tests/test_api.py::test_root, tests/test_api.py::test_current_user_in_state, tests/test_api.py::test_user_endpoint, tests/test_api.py::test_get_context, tests/test_api.py::test_crawl, tests/test_api.py::test_auth_me, tests/test_api.py::test_user_endpoint_unauthorized, tests/test_api.py::test_register_does_not_return_api_key, tests/test_missing_users_file.py::test_missing_users_file)*

------
https://chatgpt.com/codex/tasks/task_b_68b73fcad2e08322a4642993a9d1873a