### PR TITLE
Lazy-load heavy dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ Install dependencies and execute:
 pytest -q
 ```
 
+## Optional dependencies
+
+Some features rely on third‑party packages that are not strictly required for
+all deployments:
+
+- `sentence-transformers` – computing text embeddings.
+- `faiss-cpu` – similarity search over embeddings.
+- `requests` and `beautifulsoup4` – fetching and parsing web pages.
+- `pdfminer.six` or `PyPDF2` – extracting text from PDF files.
+
+Install the packages that match the features you plan to use.
+
 ## License
 
 Otec Fura is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- Delay importing heavy optional libraries in `knowledge_store.py` and provide helpful errors or fallbacks
- Document optional packages required for embedding, PDF, and URL features

## Testing
- `pytest -q` *(fails: assert 404 == 200)*

------
https://chatgpt.com/codex/tasks/task_b_68b74144ec088322bca5b5e2efb7d50e