### PR TITLE
chore: refresh model metadata JSON

### DIFF
--- a/models_meta.py
+++ b/models_meta.py
@@ -1,4 +1,9 @@
-"""Model metadata hints for Jarvik."""
+"""Model metadata hints for Jarvik.
+
+Run this module to regenerate ``static/models_meta.json``:
+
+``python -m models_meta``
+"""
 
 from __future__ import annotations
 
@@ -21,18 +26,6 @@ MODELS_HINTS: Dict[str, Dict[str, str]] = {
         "difficulty": "medium",
         "type": "code",
     },
-    "gpt4": {
-        "label": "GPT-4",
-        "description": "OpenAI GPT-4 model",
-        "difficulty": "high",
-        "type": "general",
-    },
-    "llama2": {
-        "label": "LLaMA2",
-        "description": "Meta's LLaMA2 model",
-        "difficulty": "medium",
-        "type": "general",
-    },
 }
 
 # Convenient set of allowed model identifiers
@@ -52,3 +45,19 @@ def dump_models_meta(path: str | Path) -> None:
     dest.write_text(
         json.dumps(MODELS_HINTS, indent=2, ensure_ascii=False), encoding="utf-8"
     )
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Dump MODELS_HINTS to a JSON file"
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=Path(__file__).parent / "static" / "models_meta.json",
+        help="Destination JSON file",
+    )
+    args = parser.parse_args()
+    dump_models_meta(args.path)

--- a/static/models_meta.json
+++ b/static/models_meta.json
@@ -10,17 +10,5 @@
     "description": "Meta's CodeLlama 7B model",
     "difficulty": "medium",
     "type": "code"
-  },
-  "gpt4": {
-    "label": "GPT-4",
-    "description": "OpenAI GPT-4 model",
-    "difficulty": "high",
-    "type": "general"
-  },
-  "llama2": {
-    "label": "LLaMA2",
-    "description": "Meta's LLaMA2 model",
-    "difficulty": "medium",
-    "type": "general"
   }
 }

--- a/tests/test_models_meta.py
+++ b/tests/test_models_meta.py
@@ -7,6 +7,8 @@ from models_meta import MODELS_HINTS, ALLOWED_MODELS, dump_models_meta
 def test_allowed_models():
     assert "command-r" in ALLOWED_MODELS
     assert "codellama-7b" in ALLOWED_MODELS
+    assert "gpt4" not in ALLOWED_MODELS
+    assert "llama2" not in ALLOWED_MODELS
 
 
 def test_dump_models_meta(tmp_path: Path):


### PR DESCRIPTION
## Summary
- regenerate `static/models_meta.json` from `MODELS_HINTS`
- drop obsolete GPT-4 and LLaMA2 hints
- document how to dump model metadata from `models_meta.py`

## Testing
- `pytest -q` *(fails: assert 404 == 200)*

------
https://chatgpt.com/codex/tasks/task_b_68b7486ea5ac832285faf72b5dfbd6c9