### PR TITLE
Enhance model metadata handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,17 +141,26 @@
       if (!select){ console.error('Select #model nebyl nalezen.'); return; }
       try {
         const res = await fetch("/static/models_meta.json");
-        const meta = await res.json();
-        const entries = Object.entries(meta || {});
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const meta = await res.json().catch(()=>null);
+        if (!meta || typeof meta !== 'object') throw new Error("Neplatná data models_meta.json");
+        const entries = Object.entries(meta);
         if (!entries.length) throw new Error("Prázdná odpověď models_meta.json");
         entries.sort((a,b)=> (a[1].label||a[0]).localeCompare(b[1].label||b[0]));
         for (const [id, info] of entries) {
           const opt = document.createElement("option");
+          const label = info.label || id;
           opt.value = id;
+          opt.textContent = label;
+          const extra = [info.group, info.tier].filter(Boolean).join(", ");
+          if (extra) opt.textContent += ` — ${extra}`;
+          if (info.tip || info.description) opt.title = info.tip || info.description;
           const diff = translateDifficulty(info.difficulty);
-          opt.textContent = `${info.label} (${info.description}) — tíha: ${diff}`;
+          opt.dataset.label = label;
+          opt.dataset.tip = info.tip || info.description || "";
           opt.dataset.description = info.description || "";
-          opt.dataset.label = info.label || id;
+          opt.dataset.group = info.group || "";
+          opt.dataset.tier = info.tier || "";
           opt.dataset.difficulty = diff;
           opt.dataset.type = info.type || "general";
           select.appendChild(opt);
@@ -181,9 +190,12 @@
       } else {
         const opt = sel.options[sel.selectedIndex];
         const label = opt?.dataset?.label || sel.value;
-        const desc = opt?.dataset?.description || '';
+        const tip = opt?.dataset?.tip || opt?.dataset?.description || '';
+        const tipPart = tip ? ` — ${tip}` : '';
+        const group = opt?.dataset?.group ? `, skupina: ${opt.dataset.group}` : '';
+        const tier = opt?.dataset?.tier ? `, tier: ${opt.dataset.tier}` : '';
         const diff = opt?.dataset?.difficulty ? `, tíha: ${opt.dataset.difficulty}` : '';
-        help.textContent = `${label} — ${desc}${diff}`;
+        help.textContent = `${label}${tipPart}${group}${tier}${diff}`;
       }
     }
 

--- a/models_meta.py
+++ b/models_meta.py
@@ -16,13 +16,19 @@ from typing import Dict
 MODELS_HINTS: Dict[str, Dict[str, str]] = {
     "command-r": {
         "label": "Command R",
+        "tip": "Cohere's reasoning model",
         "description": "Cohere's Command R reasoning model",
+        "group": "reasoning",
+        "tier": "premium",
         "difficulty": "medium",
         "type": "general",
     },
     "codellama-7b": {
         "label": "CodeLlama 7B",
+        "tip": "Meta's code model",
         "description": "Meta's CodeLlama 7B model",
+        "group": "code",
+        "tier": "standard",
         "difficulty": "medium",
         "type": "code",
     },

--- a/static/models_meta.json
+++ b/static/models_meta.json
@@ -1,13 +1,19 @@
 {
   "command-r": {
     "label": "Command R",
+    "tip": "Cohere's reasoning model",
     "description": "Cohere's Command R reasoning model",
+    "group": "reasoning",
+    "tier": "premium",
     "difficulty": "medium",
     "type": "general"
   },
   "codellama-7b": {
     "label": "CodeLlama 7B",
+    "tip": "Meta's code model",
     "description": "Meta's CodeLlama 7B model",
+    "group": "code",
+    "tier": "standard",
     "difficulty": "medium",
     "type": "code"
   }


### PR DESCRIPTION
## Summary
- extend model metadata with tip, group, and tier fields
- update frontend to display new hints and fall back gracefully when metadata fetch fails
- adjust generator to emit updated metadata structure

## Testing
- `pytest` *(fails: assert 404 == 401; assert 404 == 200; 6 errors)*


------
https://chatgpt.com/codex/tasks/task_b_68b749a0c0448322a0def0e0ce36f173