### PR TITLE
Add Llama3 model metadata and update tests

### DIFF
--- a/models_meta.py
+++ b/models_meta.py
@@ -32,6 +32,15 @@ MODELS_HINTS: Dict[str, Dict[str, str]] = {
         "difficulty": "medium",
         "type": "code",
     },
+    "llama3:8b": {
+        "label": "Llama3 8B",
+        "tip": "Meta's Llama3 model",
+        "description": "Meta's Llama3 8B model",
+        "group": "general",
+        "tier": "standard",
+        "difficulty": "easy",
+        "type": "general",
+    },
 }
 
 # Convenient set of allowed model identifiers

--- a/static/models_meta.json
+++ b/static/models_meta.json
@@ -16,5 +16,14 @@
     "tier": "standard",
     "difficulty": "medium",
     "type": "code"
+  },
+  "llama3:8b": {
+    "label": "Llama3 8B",
+    "tip": "Meta's Llama3 model",
+    "description": "Meta's Llama3 8B model",
+    "group": "general",
+    "tier": "standard",
+    "difficulty": "easy",
+    "type": "general"
   }
 }

--- a/tests/test_models_meta.py
+++ b/tests/test_models_meta.py
@@ -7,6 +7,7 @@ from models_meta import MODELS_HINTS, ALLOWED_MODELS, dump_models_meta
 def test_allowed_models():
     assert "command-r" in ALLOWED_MODELS
     assert "codellama-7b" in ALLOWED_MODELS
+    assert "llama3:8b" in ALLOWED_MODELS
     assert "gpt4" not in ALLOWED_MODELS
     assert "llama2" not in ALLOWED_MODELS
 


### PR DESCRIPTION
## Summary
- add Llama3 8B model definition to MODELS_HINTS
- regenerate static models metadata file
- include Llama3 8B in unit test expectations

## Testing
- `pytest -q` *(fails: assert 404 == 200 in tests expecting /auth/register)*

------
https://chatgpt.com/codex/tasks/task_b_68b763b615fc8322b615ae5b263837c5