### PR TITLE
Add health check endpoint

### DIFF
--- a/app_ask.py
+++ b/app_ask.py
@@ -121,6 +121,12 @@ def _validate_model(model: str) -> None:
         raise HTTPException(status_code=400, detail=f"Unsupported model: {model}")
 
 
+# ====== /healthz ======
+@router.get("/healthz")
+async def healthz():
+    return {"status": "ok"}
+
+
 # ====== /v1/chat ======
 @router.post("/v1/chat")
 async def v1_chat(req: ChatReq):


### PR DESCRIPTION
## Summary
- expose `/healthz` route returning status information

## Testing
- `pytest -q` *(fails: assert 404 == 200 in tests)*

------
https://chatgpt.com/codex/tasks/task_b_68b7685a2cac8322970331ff093d5a33