### PR TITLE
Add model listing endpoint and wire auth routers

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,11 @@ from fastapi import FastAPI, Depends, Request, HTTPException, Header
 from fastapi.responses import JSONResponse, FileResponse
 from pydantic import BaseModel
 from knowledge_store import KnowledgeStore
+from api.auth import router as auth_router
+from api.user_endpoint import router as user_router
+from api.get_context import router as context_router
+from api.crawler_router import router as crawler_router
+from middleware import APIKeyAuthMiddleware, refresh_users
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 log = logging.getLogger("fura")
@@ -15,23 +20,9 @@ KNOW_DIR = os.path.join(APP_DIR, "knowledge")
 os.makedirs(DATA_DIR, exist_ok=True)
 os.makedirs(KNOW_DIR, exist_ok=True)
 
-USERS_FILE = os.path.join(DATA_DIR, "users.json")
-if not os.path.exists(USERS_FILE):
-    os.makedirs(os.path.dirname(USERS_FILE), exist_ok=True)
-    # demo user
-    with open(USERS_FILE, "w", encoding="utf-8") as f:
-        json.dump([{
-            "username":"demo",
-            "email":"demo@example.com",
-            "approved": True,
-            "api_key": "demo"
-        }], f, ensure_ascii=False, indent=2)
 
 def _load_users() -> List[dict]:
-    try:
-        return json.load(open(USERS_FILE, "r", encoding="utf-8"))
-    except Exception:
-        return []
+    return refresh_users()
 
 def _find_user_by_token(token: str) -> Optional[dict]:
     token = (token or "").strip()
@@ -57,6 +48,20 @@ async def current_user(authorization: Optional[str]=Header(None)):
 
 app = FastAPI(title="Fura API", version="1.0.0")
 ks = KnowledgeStore(APP_DIR)
+
+app.include_router(auth_router)
+app.include_router(user_router)
+app.include_router(context_router)
+app.include_router(crawler_router)
+app.add_middleware(
+    APIKeyAuthMiddleware,
+    allow_paths={"/auth/register", "/auth/token", "/v1/chat", "/ask", "/v1/models"},
+)
+
+
+@app.get("/")
+async def root():
+    return {"message": "Otec Fura API"}
 
 class AddNote(BaseModel):
     title: str
@@ -92,40 +97,3 @@ async def knowledge_search(req: SearchReq, u=Depends(current_user)):
     hits = ks.search(req.query, top_k=max(1, min(20, req.top_k)))
     return {"results": hits}
 
-@app.post("/crawl")
-async def crawl(req: CrawlReq, u=Depends(current_user)):
-    if req.raw_text:
-        title = req.title or "Interní poznámka"
-        doc_id, chunks = ks.add_manual(title, req.raw_text, req.tags or ["note"])
-        return {"ok": True, "mode": "raw_text", "id": doc_id, "title": title, "chunks": chunks}
-    if req.url:
-        try:
-            doc_id, chunks = ks.add_from_url(req.url)
-            return {"ok": True, "mode": "url", "id": doc_id, "title": req.url, "chunks": chunks}
-        except Exception as e:
-            log.exception("crawl failed: %s", e)
-            raise HTTPException(status_code=400, detail=f"Failed to crawl")
-    raise HTTPException(status_code=400, detail="Missing URL or raw_text")
-
-@app.post("/get_context")
-async def get_context(req: SearchReq, u=Depends(current_user)):
-    # public memory
-    mem_path = os.path.join(APP_DIR, "memory", "public.jsonl")
-    memory = []
-    if os.path.exists(mem_path):
-        with open(mem_path, "r", encoding="utf-8") as f:
-            memory = [line.strip() for line in f if line.strip()]
-    else:
-        os.makedirs(os.path.dirname(mem_path), exist_ok=True)
-        with open(mem_path, "a", encoding="utf-8") as f:
-            f.write("Vítejte v paměti veřejných informací.\n")
-        memory = ["Vítejte v paměti veřejných informací."]
-
-    knowledge = ks.search(req.query, top_k=max(1, min(10, req.top_k)))
-    # a pár demonstračních „embedding“ řádků jako dřív:
-    embedding = [
-        "Vítejte v paměti veřejných informací.",
-        "Toto je soukromá paměť uživatele Jiri.",
-        "Transformers jsou architektura deep learningu založená na mechanismu attention.\n"
-    ]
-    return {"memory": memory, "knowledge": knowledge, "embedding": embedding}


### PR DESCRIPTION
## Summary
- expose `/v1/models` with OpenAI-like model listing and Jarvik proxy fallback
- register auth, user, context and crawl routers in the main app and add root endpoint
- test that `/v1/models` returns allowed models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b76926f18c8322acef4f6efb544f71