### PR TITLE
Require MODEL_API_KEY env var on startup

### DIFF
--- a/app_ask.py
+++ b/app_ask.py
@@ -21,7 +21,11 @@ router = APIRouter()
 
 # ====== Konfigurace z ENV (nastavíme v /etc/otec-fura/.env) ======
 MODEL_API_BASE = os.getenv("MODEL_API_BASE", "http://100.115.183.37:8095/v1").rstrip("/")
-MODEL_API_KEY = os.getenv("MODEL_API_KEY", "mojelokalnikurvitko")
+MODEL_API_KEY = os.getenv("MODEL_API_KEY")
+if not MODEL_API_KEY:
+    raise RuntimeError(
+        "MODEL_API_KEY environment variable is required on startup."
+    )
 MODEL_DEFAULT = os.getenv("MODEL_DEFAULT", "llama3:8b")
 REQUEST_TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", "120"))
 


### PR DESCRIPTION
## Summary
- Raise an error when MODEL_API_KEY is missing

## Testing
- `MODEL_API_KEY=dummy pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b76d8e5ad4832284736d8a8046176a