### PR TITLE
doc: add user management instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,35 @@ python -m venv .venv && . .venv/bin/activate
 pip install -r requirements.txt  # min: fastapi, uvicorn, httpx
 cp .env.example .env             # vyplň MODEL_API_BASE, MODEL_API_KEY atd.
 uvicorn app_ask:app --host 0.0.0.0 --port 8090
+```
+
+## Správa uživatelů
+
+Uživatelé jsou uloženi v souboru `data/users.json`. K jejich vytváření a
+schvalování slouží jednoduché skripty.
+
+### Vytvoření uživatele
+
+```bash
+./create_user.sh -u <jméno> -e <email>
+```
+
+Skript se doptá na heslo a vygeneruje API klíč. Pokud přidáte volbu
+`--approve`, bude uživatel schválen rovnou.
+
+### Schválení (uvolnění) uživatele
+
+Pokud není uživatel schválen při vytvoření, lze to provést následně
+upravením `data/users.json` nebo pomocí administračního nástroje:
+
+```bash
+python admin_tools.py approve <jméno>
+```
+
+Seznam uživatelů a další možnosti:
+
+```bash
+python admin_tools.py list       # vypíše všechny uživatele
+python admin_tools.py show <jméno>  # zobrazí API klíč
+```
+


### PR DESCRIPTION
## Summary
- explain how to create users with `create_user.sh`
- document approving and listing users via `admin_tools.py`

## Testing
- `pytest -q` *(fails: AttributeError: module app_ask has no attribute '_call_model_gateway'; 5 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68b867a5daec83229efe8c958ade423e