### PR TITLE
Fix non-working download button in web UI

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -147,7 +147,7 @@
           <textarea id="prompt" placeholder="Zadej dotaz… (Enter = odeslat, Shift+Enter = nový řádek)"></textarea>
           <div class="row" style="margin-top:.4rem">
             <button id="send" class="btn">Odeslat</button>
-            <button id="download" class="btn ghost hidden">Stáhnout odpověď (.txt)</button>
+            <a id="download" class="btn ghost hidden">Stáhnout odpověď (.txt)</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fix download answer button by converting it to an anchor link

## Testing
- `pytest` *(fails: test_root - assert 308 == 200, test_model_validation::* - AttributeError, test_v1_models_lists_allowed_models - assert 404 == 200)*

------
https://chatgpt.com/codex/tasks/task_b_68bafa38378c8322af8f34e242d53a0f