### PR TITLE
Use neon green on black for higher-contrast UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,38 +3,38 @@
   <title>Otec Fura</title>
   <style>
     :root{
-      --bg:#0a0a0a; --panel:#0f1b14; --accent:#00ff88; --accent2:#17a66a; --text:#c9f5e3; --border:#0c5b3a; --muted:#7bd8b1;
+      --bg:#000000; --panel:#000000; --accent:#00ff00; --accent2:#00ff00; --text:#00ff00; --border:#00ff00; --muted:#00ff00;
     }
     *{box-sizing:border-box}
     html,body{height:100%}
     body{margin:0;background:var(--bg);color:var(--text);font-family:ui-monospace,Menlo,Consolas,monospace}
-    header{display:flex;align-items:center;gap:12px;padding:14px 18px;border-bottom:1px solid var(--border);background:linear-gradient(180deg,#0d1410,#0a0a0a);position:sticky;top:0;z-index:5}
+    header{display:flex;align-items:center;gap:12px;padding:14px 18px;border-bottom:1px solid var(--border);background:var(--bg);position:sticky;top:0;z-index:5}
     header img.logo{height:42px;filter:drop-shadow(0 0 6px rgba(0,255,136,.25))}
     header h1{margin:0;font-size:20px;color:var(--accent)}
     .wrap{display:grid;grid-template-columns:1fr 340px;gap:16px;padding:16px}
     @media(max-width:1100px){.wrap{grid-template-columns:1fr}}
-    .card{background:var(--panel);border:1px solid var(--border);border-radius:16px;padding:14px;box-shadow:0 0 0 1px rgba(0,255,136,.05),0 8px 24px rgba(0,0,0,.25)}
+    .card{background:var(--panel);border:1px solid var(--border);border-radius:16px;padding:14px}
     .controls{display:grid;grid-template-columns:repeat(4,minmax(160px,1fr));gap:12px}
     @media(max-width:900px){.controls{grid-template-columns:1fr 1fr}}
     label.small{font-size:12px;color:var(--muted);display:block;margin-bottom:6px}
-    input[type="text"],select,textarea{width:100%;background:#111;color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px;outline:none}
+    input[type="text"],select,textarea{width:100%;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:10px;padding:10px 12px;outline:none}
     textarea{min-height:96px;resize:vertical}
-    .btn{background:#0b3a26;color:var(--accent);border:1px solid var(--accent2);padding:10px 14px;border-radius:12px;cursor:pointer;font-weight:600}
-    .btn.secondary{background:#0e1110;border-color:var(--border);color:var(--muted)}
+    .btn{background:var(--bg);color:var(--text);border:1px solid var(--border);padding:10px 14px;border-radius:12px;cursor:pointer;font-weight:600}
+    .btn.secondary{background:var(--bg);border-color:var(--border);color:var(--text)}
     .modal-overlay{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.9);display:flex;align-items:center;justify-content:center;z-index:10}
     .modal{background:var(--panel);border:1px solid var(--border);border-radius:16px;padding:20px;box-shadow:0 0 0 1px rgba(0,255,136,.05),0 8px 24px rgba(0,0,0,.25);width:320px;display:flex;flex-direction:column;gap:12px}
     .row{display:flex;gap:8px;align-items:center;margin-top:8px}
-    .pill{display:inline-flex;align-items:center;gap:6px;background:#0c1511;border:1px solid var(--border);color:var(--muted);border-radius:999px;padding:4px 10px;font-size:12px}
+    .pill{display:inline-flex;align-items:center;gap:6px;background:var(--bg);border:1px solid var(--border);color:var(--text);border-radius:999px;padding:4px 10px;font-size:12px}
     #chat{height:480px;overflow:auto;display:flex;flex-direction:column;gap:12px;padding-right:6px}
-    .bubble{border:1px solid var(--border);border-radius:14px;padding:12px;background:#0c1411}
-    .q{border-left:3px solid #2d7c57}.a{border-left:3px solid var(--accent2)}
+    .bubble{border:1px solid var(--border);border-radius:14px;padding:12px;background:var(--bg)}
+    .q{border-left:3px solid var(--border)}.a{border-left:3px solid var(--border)}
     .meta{font-size:11px;color:var(--muted);display:flex;gap:8px;margin-bottom:6px}
     .role{font-weight:700;color:var(--accent)}
     pre{white-space:pre-wrap;word-wrap:break-word}
-    details{border:1px solid var(--border);border-radius:12px;padding:8px 10px;background:#0b1210}
+    details{border:1px solid var(--border);border-radius:12px;padding:8px 10px;background:var(--bg)}
     details summary{cursor:pointer;color:var(--accent)}
-    .progress{height:3px;background:#0e1c16;border-radius:99px;overflow:hidden;margin-top:10px;display:none}
-    .progress .bar{height:100%;width:20%;background:linear-gradient(90deg,rgba(0,255,136,.3),rgba(0,255,136,.8));animation:load 1s infinite linear}
+    .progress{height:3px;background:var(--bg);border-radius:99px;overflow:hidden;margin-top:10px;display:none}
+    .progress .bar{height:100%;width:20%;background:var(--text);animation:load 1s infinite linear}
     @keyframes load{from{transform:translateX(-100%)}to{transform:translateX(500%)}}
   </style>
 </head>

--- a/webui/index.html
+++ b/webui/index.html
@@ -6,14 +6,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
     :root {
-      --bg: #0c0f0c;
-      --panel: #121612;
-      --text: #cde6cd;
-      --muted: #8cab8c;
-      --accent: #35d16f;
-      --accent-2: #19a354;
-      --danger: #ff4d4f;
-      --border: #1e241e;
+      --bg: #000000;
+      --panel: #000000;
+      --text: #00ff00;
+      --muted: #00ff00;
+      --accent: #00ff00;
+      --accent-2: #00ff00;
+      --danger: #00ff00;
+      --border: #00ff00;
       --shadow: rgba(0,0,0,0.35);
       --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
       --sans: Inter, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, "Apple Color Emoji","Segoe UI Emoji";
@@ -26,10 +26,10 @@
     header {
       position: sticky; top: 0; z-index: 5;
       display: flex; align-items: center; gap: .8rem;
-      padding: .8rem 1rem; background: linear-gradient(180deg, #101410 0%, #0c0f0c 100%);
+      padding: .8rem 1rem; background: var(--bg);
       border-bottom: 1px solid var(--border); box-shadow: 0 6px 20px var(--shadow);
     }
-    #logo { height: 28px; width: 28px; filter: drop-shadow(0 0 6px rgba(53,209,111,.5)); }
+    #logo { height: 28px; width: 28px; filter: drop-shadow(0 0 6px rgba(0,255,0,.5)); }
     #logo.spin { animation: spin 1.2s linear infinite; }
     @keyframes spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }
 
@@ -47,28 +47,28 @@
     .row { display:flex; align-items:center; gap:8px; flex-wrap: wrap; }
     .sep { height: 8px; }
     input[type="password"], input[type="text"], select, textarea {
-      width: 100%; box-sizing: border-box; background: #0f140f; color: var(--text);
+      width: 100%; box-sizing: border-box; background: var(--bg); color: var(--text);
       border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; outline: none;
     }
     textarea { min-height: 100px; resize: vertical; font-family: var(--sans); }
     .btn {
-      background: var(--accent); color: #001a0a; border: none; padding: 8px 12px; border-radius: 8px;
-      font-weight: 600; cursor: pointer; box-shadow: 0 6px 16px rgba(53,209,111,.25);
+      background: var(--bg); color: var(--text); border: 1px solid var(--border); padding: 8px 12px; border-radius: 8px;
+      font-weight: 600; cursor: pointer; box-shadow: 0 6px 16px rgba(0,255,0,.25);
     }
     .btn:hover { filter: brightness(1.06); }
-    .ghost { background: transparent; color: var(--text); border: 1px solid var(--border); }
+    .ghost { background: var(--bg); color: var(--text); border: 1px solid var(--border); }
     .small { font-size: 12px; color: var(--muted); }
     .hidden { display: none !important; }
     pre.block {
-      background:#0f140f; border:1px solid var(--border); border-radius:8px; padding:8px; overflow:auto; max-height:40vh;
+      background:var(--bg); border:1px solid var(--border); border-radius:8px; padding:8px; overflow:auto; max-height:40vh;
       font-family: var(--mono); white-space: pre-wrap;
     }
     #chat { display:flex; flex-direction:column; gap:10px; min-height: 50vh; }
     #messages { display:flex; flex-direction:column; gap:10px; }
     .msg { padding:10px 12px; border-radius:10px; border:1px solid var(--border); }
-    .user { background:#0e160f; }
-    .ai   { background:#0a140c; }
-    .system { background:#131313; color:#aaa; }
+    .user { background:var(--bg); }
+    .ai   { background:var(--bg); }
+    .system { background:var(--bg); color:var(--text); }
     option.uncensored { color: var(--danger); font-weight: 600; }
     .tip { color: var(--muted); font-size: 12px; margin-top: 4px; }
     @media (max-width: 980px) {
@@ -104,7 +104,7 @@
         <option value="auto" selected>Automatický výběr</option>
         <!-- dynamicky doplníme z /v1/models -->
       </select>
-      <div class="tip">„uncensored“ modely jsou <b style="color:#ff4d4f">červené</b> a nevybírají se v režimu „Automaticky“.</div>
+      <div class="tip">„uncensored“ modely jsou <b style="color:var(--danger)">červené</b> a nevybírají se v režimu „Automaticky“.</div>
 
       <div class="sep"></div>
 

--- a/webui/index_bak.html
+++ b/webui/index_bak.html
@@ -5,18 +5,18 @@
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>Otec FURA</title>
   <style>
-    :root { --bg:#0e1714; --fg:#e6f2ed; --muted:#9acbb9; --card:#0f1d18; --border:#17362c; --accent:#1d5c47; }
+    :root { --bg:#000000; --fg:#00ff00; --muted:#00ff00; --card:#000000; --border:#00ff00; --accent:#00ff00; }
     html,body{height:100%} body{margin:0;background:var(--bg);color:var(--fg);font:15px system-ui, sans-serif}
     .wrap{max-width:980px;margin:24px auto;padding:0 16px}
     .row{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin:8px 0}
     .card{background:var(--card);border:1px solid var(--border);border-radius:14px;padding:12px;margin:12px 0}
     label{opacity:.9}
     select,input,textarea,button{font:inherit}
-    select,input,textarea{background:#0b1410;color:var(--fg);border:1px solid var(--border);border-radius:10px;padding:8px}
+    select,input,textarea{background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:10px;padding:8px}
     textarea{width:100%;min-height:120px}
-    button{background:var(--accent);color:#d9f1e8;border:none;border-radius:10px;padding:10px 14px;cursor:pointer}
+    button{background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:10px;padding:10px 14px;cursor:pointer}
     .muted{color:var(--muted)}
-    .log{white-space:pre-wrap;background:#0a1512;border:1px dashed var(--border);border-radius:10px;padding:12px;min-height:120px}
+    .log{white-space:pre-wrap;background:var(--bg);border:1px dashed var(--border);border-radius:10px;padding:12px;min-height:120px}
     header{display:flex;justify-content:space-between;align-items:center;margin:16px 0 8px}
     .pill{border:1px solid var(--border);padding:4px 8px;border-radius:999px;font-size:12px;color:var(--muted)}
   </style>

--- a/webui/style.css
+++ b/webui/style.css
@@ -1,12 +1,12 @@
 :root{
-  --bg:#0b0f0b;
-  --panel:#0f1510;
-  --muted:#9ee6a8a6;
-  --text:#baf5c3;
-  --accent:#00ff84;
-  --accent-weak:#00d06c;
-  --danger:#ff5c5c;
-  --border:#153a22;
+  --bg:#000000;
+  --panel:#000000;
+  --muted:#00ff00;
+  --text:#00ff00;
+  --accent:#00ff00;
+  --accent-weak:#00ff00;
+  --danger:#00ff00;
+  --border:#00ff00;
 }
 
 *{box-sizing:border-box}
@@ -14,7 +14,7 @@ html,body{height:100%}
 html{scroll-behavior:smooth}
 body{
   margin:0;
-  background:radial-gradient(1000px 500px at -10% -40%, #0d160f 0%, var(--bg) 50%) fixed;
+  background:var(--bg);
   color:var(--text);
   font:16px/1.5 ui-sans-serif,system-ui,Segoe UI,Roboto,Arial;
 }
@@ -26,16 +26,16 @@ body{
 .topbar{
   display:flex; align-items:center; justify-content:space-between;
   padding:10px 16px; border-bottom:1px solid var(--border);
-  background:linear-gradient(180deg, #0e160f 0%, #0b0f0b 100%);
+  background:var(--bg);
   position:sticky; top:0; z-index:10;
 }
 .brand{display:flex; align-items:center; gap:.75rem}
-#logo{width:34px; height:34px; filter:drop-shadow(0 0 6px #00ff8444)}
+#logo{width:34px; height:34px; filter:drop-shadow(0 0 6px #00ff0044)}
 #logo.spin{animation:spin 1s linear infinite}
 @keyframes spin{to{transform:rotate(360deg)}}
 .dot{
   width:10px; height:10px; border-radius:999px; margin-left:.25rem;
-  background:linear-gradient(180deg, #00ff84, #00a95c);
+  background:var(--text);
   box-shadow:0 0 0 0 rgba(0,255,132,.6);
   animation:pulse 2s infinite;
 }
@@ -53,7 +53,7 @@ body{
 }
 @media (max-width:1200px){ .grid{grid-template-columns: 300px 1fr} aside{display:none}}
 .panel{
-  background:linear-gradient(180deg, #0f1611, #0b120d);
+  background:var(--bg);
   border:1px solid var(--border);
   border-radius:14px; padding:14px;
   box-shadow:0 10px 30px rgba(0,0,0,.25), inset 0 1px 0 rgba(255,255,255,.03);
@@ -64,20 +64,20 @@ body{
 .sep{height:10px}
 
 input[type="text"], input[type="password"], select, textarea{
-  width:100%; border:1px solid var(--border); background:#0c120d; color:var(--text);
+  width:100%; border:1px solid var(--border); background:var(--bg); color:var(--text);
   border-radius:10px; padding:.6rem .7rem; outline:none;
 }
 textarea{min-height:110px; resize:vertical}
 
 .btn{
-  border:1px solid var(--accent-weak); color:#001a0c; background:var(--accent);
+  border:1px solid var(--border); color:var(--text); background:var(--bg);
   padding:.55rem .9rem; border-radius:12px; cursor:pointer; font-weight:600;
-  box-shadow:0 8px 24px rgba(0,255,132,.2);
+  box-shadow:0 8px 24px rgba(0,255,0,.2);
 }
 .btn:hover{filter:brightness(1.06)}
 .btn:disabled{opacity:.6; cursor:not-allowed}
 .btn.ghost{
-  background:transparent; color:var(--accent); border-color:var(--border);
+  background:var(--bg); color:var(--text); border-color:var(--border);
   box-shadow:none;
 }
 .btn.small{padding:.35rem .6rem; font-size:.85rem}
@@ -89,13 +89,13 @@ textarea{min-height:110px; resize:vertical}
 }
 .bubble{
   max-width:80%; padding:.75rem .9rem; border-radius:14px; border:1px solid var(--border);
-  background:#0c130e;
+  background:var(--bg);
 }
 .bubble.user{
-  margin-left:auto; background:#0e1510; border-color:#1f5a36;
+  margin-left:auto; background:var(--bg); border-color:var(--border);
 }
 .bubble.ai{
-  margin-right:auto; border-color:#1b4e30; box-shadow:inset 0 0 0 1px #0d2618;
+  margin-right:auto; border-color:var(--border); box-shadow:inset 0 0 0 1px var(--border);
 }
 .bubble .role{display:block; font-size:.75rem; color:var(--muted); margin-bottom:.25rem}
 .bubble pre{white-space:pre-wrap; margin:0; font-family:inherit; color:var(--text)}
@@ -103,7 +103,7 @@ textarea{min-height:110px; resize:vertical}
 .composer{position:sticky; bottom:0; background:transparent; padding-top:8px}
 
 details{
-  background:#0c120d; border:1px solid var(--border); border-radius:12px; padding:8px 10px;
+  background:var(--bg); border:1px solid var(--border); border-radius:12px; padding:8px 10px;
 }
 details>summary{cursor:pointer; color:var(--text); user-select:none}
-.block{background:#08100a; border:1px dashed #124728; border-radius:8px; padding:8px; overflow:auto}
+.block{background:var(--bg); border:1px dashed var(--border); border-radius:8px; padding:8px; overflow:auto}


### PR DESCRIPTION
## Summary
- switch all UI templates to black backgrounds with neon green text and accents
- ensure buttons, panels, and chat bubbles follow the retro terminal palette

## Testing
- `pytest` *(fails: assert 308 == 200; AttributeError in app_ask; httpx.ConnectError)*

------
https://chatgpt.com/codex/tasks/task_b_68bc47f38374832291af7ac2ddfcdbb1