### PR TITLE
feat: recursive knowledge reindexing

### DIFF
--- a/tests/test_knowledge_store.py
+++ b/tests/test_knowledge_store.py
@@ -1,0 +1,37 @@
+import numpy as np
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from knowledge_store import KnowledgeStore
+
+
+def _dummy_embed(self, texts):
+    return np.zeros((len(texts), self._dim), dtype="float32")
+
+
+def _make_files(root: Path):
+    (root / "a.txt").write_text("hello", encoding="utf-8")
+    sub = root / "sub"
+    sub.mkdir()
+    (sub / "b.md").write_text("world", encoding="utf-8")
+    deep = sub / "deep"
+    deep.mkdir()
+    (deep / "c.txt").write_text("deep", encoding="utf-8")
+
+
+def test_reindex_nested_files(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _make_files(data_dir)
+    store_dir = tmp_path / "store"
+    ks = KnowledgeStore(str(store_dir))
+    monkeypatch.setattr(KnowledgeStore, "_embed", _dummy_embed, raising=False)
+
+    res1 = ks.reindex_folder(str(data_dir))
+    assert res1 == {"docs": 3, "chunks": 3}
+    res2 = ks.reindex_folder(str(data_dir))
+    assert res2 == {"docs": 3, "chunks": 3}
+    assert len(ks._docs) == 3
+    assert ks._vectors.shape[0] == 3


### PR DESCRIPTION
## Summary
- traverse subdirectories when reindexing knowledge
- reset docs and index to avoid duplicates
- test recursive reindexing and index reset

## Testing
- `pytest tests/test_knowledge_store.py -q`
- `pytest -q` *(fails: test_root, test_v1_chat_rejects_invalid_model, test_v1_chat_allows_valid_model, test_ask_rejects_invalid_model, test_ask_allows_valid_model, test_v1_models_lists_allowed_models)*

------
https://chatgpt.com/codex/tasks/task_b_68bc5324fde08322864fa48cc2dce377