### PR TITLE
feat: add knowledge rebuild endpoint

### DIFF
--- a/api_setup.md
+++ b/api_setup.md
@@ -21,7 +21,7 @@ CrawlReq: {"url": str?, "raw_text": str?, "title": str?, "tags": [str]?}
 Endpoints
 Metoda & URL	Vstup	Odpověď	Popis
 POST /knowledge/add	AddNote	{"ok": True, "id": str, "title": str, "chunks": int}	Uloží ručně zadaný text do znalostní databáze (FAISS + metadata).
-POST /admin/reindex_knowledge	–	{"ok": True, "docs": int, "chunks": int}	Znovu projde soubory ve složce knowledge/ a rebuilduje index.
+POST /admin/reindex_knowledge	–	{"ok": True, "docs": int, "chunks": int}	Provede kompletní rebuild: smaže uložené dokumenty i vektory a znovu projde soubory ve složce knowledge/
 POST /knowledge/search	SearchReq	{"results": [...]}	Vyhledá podobné úryvky v indexu. Každý výsledek obsahuje title, source, tags, score, snippet.
 POST /crawl	CrawlReq	- Pro raw_text: {"ok": True, "mode": "raw_text", "id": str, "title": str, "chunks": int} - Pro url: {"ok": True, "mode": "url", "id": str, "title": str, "chunks": int}	Přidá do znalostní báze buď zadaný text, nebo stáhne obsah z URL a zaindexuje jej. Chybí-li oboje, vrací 400.
 POST /get_context	{"query": str, "user": str=\"anonymous\", "remember": bool=False}	{"memory": [...], "knowledge": [...], "embedding": [...]}	Vrací kontext z paměti i znalostí. Pokud remember=True, dotaz se uloží do privátní paměti uživatele.

--- a/main.py
+++ b/main.py
@@ -108,7 +108,7 @@ async def knowledge_add(body: AddNote, u=Depends(current_user)):
 
 @app.post("/admin/reindex_knowledge")
 async def admin_reindex(u=Depends(current_user)):
-    res = ks.reindex_folder(KNOW_DIR)
+    res = ks.rebuild_folder(KNOW_DIR)
     return {"ok": True, **res}
 
 

--- a/tests/test_knowledge_store.py
+++ b/tests/test_knowledge_store.py
@@ -29,9 +29,9 @@ def test_reindex_nested_files(tmp_path, monkeypatch):
     ks = KnowledgeStore(str(store_dir))
     monkeypatch.setattr(KnowledgeStore, "_embed", _dummy_embed, raising=False)
 
-    res1 = ks.reindex_folder(str(data_dir))
+    res1 = ks.rebuild_folder(str(data_dir))
     assert res1 == {"docs": 3, "chunks": 3}
-    res2 = ks.reindex_folder(str(data_dir))
+    res2 = ks.rebuild_folder(str(data_dir))
     assert res2 == {"docs": 3, "chunks": 3}
     assert len(ks._docs) == 3
     assert ks._vectors.shape[0] == 3


### PR DESCRIPTION
## Summary
- add `rebuild_folder` to KnowledgeStore that clears existing data before indexing and persists empty index
- use rebuild in `/admin/reindex_knowledge` endpoint
- document rebuild behaviour and update tests

## Testing
- `pytest -q` *(fails: assert 308 == 200, AttributeError: module 'app_ask' has no attribute '_call_model_gateway', httpx.ConnectError: boom)*

------
https://chatgpt.com/codex/tasks/task_b_68bc56a15d288322b6e07ae39bb1db00