### PR TITLE
Allow dynamic knowledge reload

### DIFF
--- a/tests/test_search_knowledge_reload.py
+++ b/tests/test_search_knowledge_reload.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure module import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from api import search_knowledge
+
+
+def test_new_files_become_searchable(tmp_path, monkeypatch):
+    # Point the knowledge loader to a temporary directory
+    monkeypatch.setattr(search_knowledge, "KNOWLEDGE_DIR", tmp_path)
+    search_knowledge.reload_knowledge()
+
+    # Initial file and query to populate caches
+    (tmp_path / "first.txt").write_text("alpha beta", encoding="utf-8")
+    assert any("alpha" in r for r in search_knowledge.search_knowledge("alpha"))
+
+    # Add new file after initial load
+    (tmp_path / "second.txt").write_text("fresh fact", encoding="utf-8")
+
+    # The new file should be discovered without restarting
+    results = search_knowledge.search_knowledge("fresh")
+    assert any("fresh" in r for r in results)


### PR DESCRIPTION
## Summary
- add `reload_knowledge` to clear cached documents
- reload knowledge when files change on disk
- test that new files become searchable without restart

## Testing
- `pytest tests/test_search_knowledge_reload.py`
- `pytest` *(fails: tests/test_api.py::test_root, tests/test_model_validation.py::test_v1_chat_rejects_invalid_model, tests/test_model_validation.py::test_v1_chat_allows_valid_model, tests/test_model_validation.py::test_ask_rejects_invalid_model, tests/test_model_validation.py::test_ask_allows_valid_model, tests/test_model_validation.py::test_v1_models_lists_allowed_models)*

------
https://chatgpt.com/codex/tasks/task_b_68bc5a2937308322b57e83c0634d963a